### PR TITLE
Fix 1.21 crash when registering serializer

### DIFF
--- a/src/Networking/MpPacketSerializer.cpp
+++ b/src/Networking/MpPacketSerializer.cpp
@@ -12,7 +12,8 @@ namespace MultiplayerCore::Networking {
 		//registeredTypes = std::move(TypeDictionary());
 		packetHandlers = std::move(CallbackDictionary());
 		getLogger().debug("Registering MpPacketSerializer");
-		_sessionManager->RegisterSerializer((GlobalNamespace::MultiplayerSessionManager_MessageType)MpPacketSerializer::Packet_ID, reinterpret_cast<GlobalNamespace::INetworkPacketSubSerializer_1<GlobalNamespace::IConnectedPlayer*>*>(this));
+        GlobalNamespace::MultiplayerSessionManager_MessageType messageType = (GlobalNamespace::MultiplayerSessionManager_MessageType)100;
+		_sessionManager->RegisterSerializer(messageType, reinterpret_cast<GlobalNamespace::INetworkPacketSubSerializer_1<GlobalNamespace::IConnectedPlayer*>*>(this));
 		getLogger().debug("MpPacketSerializer Registered Successfully");
 	}
 


### PR DESCRIPTION
The MessageType enum was changed in 1.20 and now in 1.21 it was reverted so it broke.