### PR TITLE
Revert back to il2cpp threads and update to fixed dependency

### DIFF
--- a/qpm.json
+++ b/qpm.json
@@ -119,7 +119,7 @@
     },
     {
       "id": "beatsaverplusplus",
-      "versionRange": "^0.2.1",
+      "versionRange": "^0.2.2",
       "additionalData": {}
     },
     {

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/QuestPackageManager/QPM.Package/refs/heads/main/qpm.shared.schema.json",
   "config": {
     "version": "0.1.0",
     "sharedDir": "shared",
@@ -119,7 +120,7 @@
       },
       {
         "id": "beatsaverplusplus",
-        "versionRange": "^0.2.1",
+        "versionRange": "^0.2.2",
         "additionalData": {}
       },
       {
@@ -130,6 +131,117 @@
     ]
   },
   "restoredDependencies": [
+    {
+      "dependency": {
+        "id": "sombrero",
+        "versionRange": "=0.1.43",
+        "additionalData": {
+          "headersOnly": true,
+          "branchName": "version/v0_1_43"
+        }
+      },
+      "version": "0.1.43"
+    },
+    {
+      "dependency": {
+        "id": "beatsaverplusplus",
+        "versionRange": "=0.2.2",
+        "additionalData": {
+          "soLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.2/libbeatsaverplusplus.so",
+          "debugSoLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.2/debug_libbeatsaverplusplus.so",
+          "overrideSoName": "libbeatsaverplusplus.so",
+          "modLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.2/BeatSaverPlusPlus.qmod",
+          "branchName": "version/v0_2_2",
+          "cmake": false
+        }
+      },
+      "version": "0.2.2"
+    },
+    {
+      "dependency": {
+        "id": "bs-cordl",
+        "versionRange": "=4008.0.0",
+        "additionalData": {
+          "headersOnly": true,
+          "branchName": "version/v4008_0_0",
+          "compileOptions": {
+            "includePaths": [
+              "include"
+            ],
+            "cppFeatures": [],
+            "cppFlags": [
+              "-DNEED_UNSAFE_CSHARP",
+              "-fdeclspec",
+              "-DUNITY_2021",
+              "-DHAS_CODEGEN",
+              "-Wno-invalid-offsetof"
+            ]
+          }
+        }
+      },
+      "version": "4008.0.0"
+    },
+    {
+      "dependency": {
+        "id": "lapiz",
+        "versionRange": "=0.2.23",
+        "additionalData": {
+          "soLink": "https://github.com/raineaeternal/Lapiz/releases/download/v0.2.23/liblapiz.so",
+          "debugSoLink": "https://github.com/raineaeternal/Lapiz/releases/download/v0.2.23/debug_liblapiz.so",
+          "overrideSoName": "liblapiz.so",
+          "modLink": "https://github.com/raineaeternal/Lapiz/releases/download/v0.2.23/Lapiz.qmod",
+          "branchName": "version/v0_2_23",
+          "cmake": true
+        }
+      },
+      "version": "0.2.23"
+    },
+    {
+      "dependency": {
+        "id": "tinyxml2",
+        "versionRange": "=10.0.0",
+        "additionalData": {
+          "soLink": "https://github.com/MillzyDev/NDK-tinyxml2/releases/download/v10.0.0/libtinyxml2.so",
+          "debugSoLink": "https://github.com/MillzyDev/NDK-tinyxml2/releases/download/v10.0.0/debug_libtinyxml2.so",
+          "overrideSoName": "libtinyxml2.so",
+          "modLink": "https://github.com/MillzyDev/NDK-tinyxml2/releases/download/v10.0.0/tinyxml2.qmod",
+          "branchName": "version/v10_0_0",
+          "cmake": true
+        }
+      },
+      "version": "10.0.0"
+    },
+    {
+      "dependency": {
+        "id": "fmt",
+        "versionRange": "=11.0.2",
+        "additionalData": {
+          "headersOnly": true,
+          "branchName": "version/v11_0_2",
+          "compileOptions": {
+            "systemIncludes": [
+              "fmt/include/"
+            ],
+            "cppFlags": [
+              "-DFMT_HEADER_ONLY"
+            ]
+          }
+        }
+      },
+      "version": "11.0.2"
+    },
+    {
+      "dependency": {
+        "id": "capstone",
+        "versionRange": "=0.1.0",
+        "additionalData": {
+          "staticLinking": true,
+          "soLink": "https://github.com/sc2ad/capstone-qpm/releases/download/v0.1.0/libcapstone.a",
+          "overrideSoName": "libcapstone.a"
+        }
+      },
+      "version": "0.1.0"
+    },
     {
       "dependency": {
         "id": "web-utils",
@@ -163,71 +275,16 @@
     },
     {
       "dependency": {
-        "id": "bsml",
-        "versionRange": "=0.4.55",
+        "id": "scotland2",
+        "versionRange": "=0.1.6",
         "additionalData": {
-          "soLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/libbsml.so",
-          "debugSoLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/debug_libbsml.so",
-          "overrideSoName": "libbsml.so",
-          "modLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/BSML.qmod",
-          "branchName": "version/v0_4_55",
-          "cmake": true
+          "soLink": "https://github.com/sc2ad/scotland2/releases/download/v0.1.6/libsl2.so",
+          "debugSoLink": "https://github.com/sc2ad/scotland2/releases/download/v0.1.6/debug_libsl2.so",
+          "overrideSoName": "libsl2.so",
+          "branchName": "version/v0_1_6"
         }
       },
-      "version": "0.4.55"
-    },
-    {
-      "dependency": {
-        "id": "sombrero",
-        "versionRange": "=0.1.43",
-        "additionalData": {
-          "headersOnly": true,
-          "branchName": "version/v0_1_43"
-        }
-      },
-      "version": "0.1.43"
-    },
-    {
-      "dependency": {
-        "id": "capstone",
-        "versionRange": "=0.1.0",
-        "additionalData": {
-          "staticLinking": true,
-          "soLink": "https://github.com/sc2ad/capstone-qpm/releases/download/v0.1.0/libcapstone.a",
-          "overrideSoName": "libcapstone.a"
-        }
-      },
-      "version": "0.1.0"
-    },
-    {
-      "dependency": {
-        "id": "songcore",
-        "versionRange": "=1.1.24",
-        "additionalData": {
-          "soLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/libsongcore.so",
-          "debugSoLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/debug_libsongcore.so",
-          "overrideSoName": "libsongcore.so",
-          "modLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/SongCore.qmod",
-          "branchName": "version/v1_1_24",
-          "cmake": true
-        }
-      },
-      "version": "1.1.24"
-    },
-    {
-      "dependency": {
-        "id": "tinyxml2",
-        "versionRange": "=10.0.0",
-        "additionalData": {
-          "soLink": "https://github.com/MillzyDev/NDK-tinyxml2/releases/download/v10.0.0/libtinyxml2.so",
-          "debugSoLink": "https://github.com/MillzyDev/NDK-tinyxml2/releases/download/v10.0.0/debug_libtinyxml2.so",
-          "overrideSoName": "libtinyxml2.so",
-          "modLink": "https://github.com/MillzyDev/NDK-tinyxml2/releases/download/v10.0.0/tinyxml2.qmod",
-          "branchName": "version/v10_0_0",
-          "cmake": true
-        }
-      },
-      "version": "10.0.0"
+      "version": "0.1.6"
     },
     {
       "dependency": {
@@ -245,25 +302,6 @@
         }
       },
       "version": "0.1.9"
-    },
-    {
-      "dependency": {
-        "id": "paper2_scotland2",
-        "versionRange": "=4.6.4",
-        "additionalData": {
-          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.6.4/libpaper2_scotland2.so",
-          "overrideSoName": "libpaper2_scotland2.so",
-          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.6.4/paper2_scotland2.qmod",
-          "branchName": "version/v4_6_4",
-          "compileOptions": {
-            "systemIncludes": [
-              "shared/utfcpp/source"
-            ]
-          },
-          "cmake": false
-        }
-      },
-      "version": "4.6.4"
     },
     {
       "dependency": {
@@ -287,27 +325,22 @@
     },
     {
       "dependency": {
-        "id": "bs-cordl",
-        "versionRange": "=4008.0.0",
+        "id": "paper2_scotland2",
+        "versionRange": "=4.6.4",
         "additionalData": {
-          "headersOnly": true,
-          "branchName": "version/v4008_0_0",
+          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.6.4/libpaper2_scotland2.so",
+          "overrideSoName": "libpaper2_scotland2.so",
+          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.6.4/paper2_scotland2.qmod",
+          "branchName": "version/v4_6_4",
           "compileOptions": {
-            "includePaths": [
-              "include"
-            ],
-            "cppFeatures": [],
-            "cppFlags": [
-              "-DNEED_UNSAFE_CSHARP",
-              "-fdeclspec",
-              "-DUNITY_2021",
-              "-DHAS_CODEGEN",
-              "-Wno-invalid-offsetof"
+            "systemIncludes": [
+              "shared/utfcpp/source"
             ]
-          }
+          },
+          "cmake": false
         }
       },
-      "version": "4008.0.0"
+      "version": "4.6.4"
     },
     {
       "dependency": {
@@ -342,65 +375,33 @@
     },
     {
       "dependency": {
-        "id": "lapiz",
-        "versionRange": "=0.2.23",
+        "id": "songcore",
+        "versionRange": "=1.1.24",
         "additionalData": {
-          "soLink": "https://github.com/raineaeternal/Lapiz/releases/download/v0.2.23/liblapiz.so",
-          "debugSoLink": "https://github.com/raineaeternal/Lapiz/releases/download/v0.2.23/debug_liblapiz.so",
-          "overrideSoName": "liblapiz.so",
-          "modLink": "https://github.com/raineaeternal/Lapiz/releases/download/v0.2.23/Lapiz.qmod",
-          "branchName": "version/v0_2_23",
+          "soLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/libsongcore.so",
+          "debugSoLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/debug_libsongcore.so",
+          "overrideSoName": "libsongcore.so",
+          "modLink": "https://github.com/raineaeternal/Quest-SongCore/releases/download/v1.1.24/SongCore.qmod",
+          "branchName": "version/v1_1_24",
           "cmake": true
         }
       },
-      "version": "0.2.23"
+      "version": "1.1.24"
     },
     {
       "dependency": {
-        "id": "scotland2",
-        "versionRange": "=0.1.6",
+        "id": "bsml",
+        "versionRange": "=0.4.55",
         "additionalData": {
-          "soLink": "https://github.com/sc2ad/scotland2/releases/download/v0.1.6/libsl2.so",
-          "debugSoLink": "https://github.com/sc2ad/scotland2/releases/download/v0.1.6/debug_libsl2.so",
-          "overrideSoName": "libsl2.so",
-          "branchName": "version/v0_1_6"
+          "soLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/libbsml.so",
+          "debugSoLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/debug_libbsml.so",
+          "overrideSoName": "libbsml.so",
+          "modLink": "https://github.com/bsq-ports/Quest-BSML/releases/download/v0.4.55/BSML.qmod",
+          "branchName": "version/v0_4_55",
+          "cmake": true
         }
       },
-      "version": "0.1.6"
-    },
-    {
-      "dependency": {
-        "id": "beatsaverplusplus",
-        "versionRange": "=0.2.1",
-        "additionalData": {
-          "soLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.1/libbeatsaverplusplus.so",
-          "debugSoLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.1/debug_libbeatsaverplusplus.so",
-          "overrideSoName": "libbeatsaverplusplus.so",
-          "modLink": "https://github.com/bsq-ports/BeatSaverPlusPlus/releases/download/v0.2.1/BeatSaverPlusPlus.qmod",
-          "branchName": "version/v0_2_1",
-          "cmake": false
-        }
-      },
-      "version": "0.2.1"
-    },
-    {
-      "dependency": {
-        "id": "fmt",
-        "versionRange": "=11.0.2",
-        "additionalData": {
-          "headersOnly": true,
-          "branchName": "version/v11_0_2",
-          "compileOptions": {
-            "systemIncludes": [
-              "fmt/include/"
-            ],
-            "cppFlags": [
-              "-DFMT_HEADER_ONLY"
-            ]
-          }
-        }
-      },
-      "version": "11.0.2"
+      "version": "0.4.55"
     }
   ]
 }

--- a/src/Beatmaps/BeatSaverPreviewMediaData.cpp
+++ b/src/Beatmaps/BeatSaverPreviewMediaData.cpp
@@ -30,7 +30,7 @@ namespace MultiplayerCore::Beatmaps {
         }
 
         if (!_coverImageTask || _coverImageTask->IsCancellationRequested) {
-            _coverImageTask = StartThread<UnityEngine::Sprite*>([this]() -> UnityEngine::Sprite* {
+            _coverImageTask = StartTask<UnityEngine::Sprite*>([this]() -> UnityEngine::Sprite* {
                 auto beatmapRes = BeatSaver::API::GetBeatmapByHash(_levelHash);
                 if (beatmapRes.DataParsedSuccessful()) {
                     auto versions = beatmapRes.responseData->GetVersions();
@@ -70,7 +70,7 @@ namespace MultiplayerCore::Beatmaps {
         }
 
         if (!_audioClipTask || _audioClipTask->IsCancellationRequested) {
-            _audioClipTask = StartThread<UnityEngine::AudioClip*>([this]() -> UnityEngine::AudioClip* {
+            _audioClipTask = StartTask<UnityEngine::AudioClip*>([this]() -> UnityEngine::AudioClip* {
                 auto beatmapRes = BeatSaver::API::GetBeatmapByHash(_levelHash);
 
                 if (beatmapRes.DataParsedSuccessful()) {

--- a/src/Hooks/PlatformAuthenticationTokenProviderHooks.cpp
+++ b/src/Hooks/PlatformAuthenticationTokenProviderHooks.cpp
@@ -34,7 +34,7 @@ System::Threading::Tasks::Task_1<GlobalNamespace::AuthenticationToken>*, GlobalN
     if (isPico.load()) self->_platform = GlobalNamespace::AuthenticationToken::Platform(20); // Set platform to 20 for Pico
 
     auto t = PlatformAuthenticationTokenProvider_GetAuthenticationToken(self);
-    return MultiplayerCore::StartThread<GlobalNamespace::AuthenticationToken>([=](){
+    return MultiplayerCore::StartTask<GlobalNamespace::AuthenticationToken>([=](){
         using namespace std::chrono_literals;
         while (!(t->IsCompleted || t->IsCanceled)) std::this_thread::sleep_for(50ms);
         GlobalNamespace::AuthenticationToken token = t->ResultOnSuccess;
@@ -110,7 +110,7 @@ MAKE_AUTO_HOOK_ORIG_MATCH(OculusPlatformUserModel_GetUserInfo, &GlobalNamespace:
     if (isPico.load()) {
         DEBUG("Got Orig task, on Pico, starting custom task");
         try {
-            return MultiplayerCore::StartThread<GlobalNamespace::UserInfo*>([=](){
+            return MultiplayerCore::StartTask<GlobalNamespace::UserInfo*>([=](){
                 using namespace std::chrono_literals;
                 DEBUG("Start UserInfoTask");
                 while (!(t->IsCompleted || t->IsCanceled)) std::this_thread::sleep_for(50ms);

--- a/src/Hooks/ProvideBeatsaverLevelHooks.cpp
+++ b/src/Hooks/ProvideBeatsaverLevelHooks.cpp
@@ -25,7 +25,7 @@ MAKE_AUTO_HOOK_MATCH(BeatmapLevelsModel_CheckBeatmapLevelDataExistsAsync, &Globa
         if (SongCore::API::Loading::GetLevelByHash(levelHash)) return t;
 
         // custom level, not locally available, get on beatsaver
-        return MultiplayerCore::StartThread<bool>([=](){
+        return MultiplayerCore::StartTask<bool>([=](){
             using namespace std::chrono_literals;
             while (!(t->IsCompleted || t->IsCanceled)) std::this_thread::sleep_for(50ms);
             // if orig says it's available, cool beans

--- a/src/Objects/MpEntitlementChecker.cpp
+++ b/src/Objects/MpEntitlementChecker.cpp
@@ -81,7 +81,7 @@ namespace MultiplayerCore::Objects {
         // therefore we get the base task before we enter our own new task which will await things, and is the one that we will return
         auto baseTask = NetworkPlayerEntitlementChecker::GetEntitlementStatus(levelId);
 
-        auto task = StartThread<GlobalNamespace::EntitlementsStatus>([this, baseTask, levelId](){
+        auto task = StartTask<GlobalNamespace::EntitlementsStatus>([this, baseTask, levelId](){
             using namespace std::chrono_literals;
 
             std::string levelHash(HashFromLevelID(levelId));

--- a/src/Objects/MpLevelLoader.cpp
+++ b/src/Objects/MpLevelLoader.cpp
@@ -145,7 +145,7 @@ namespace MultiplayerCore::Objects {
     }
 
     System::Threading::Tasks::Task_1<GlobalNamespace::LoadBeatmapLevelDataResult>* MpLevelLoader::StartDownloadBeatmapLevelAsyncTask(std::string levelId, System::Threading::CancellationToken cancellationToken) {
-        return StartThread<GlobalNamespace::LoadBeatmapLevelDataResult>([this, levelId](CancellationToken token) -> GlobalNamespace::LoadBeatmapLevelDataResult {
+        return StartTask<GlobalNamespace::LoadBeatmapLevelDataResult>([this, levelId](CancellationToken token) -> GlobalNamespace::LoadBeatmapLevelDataResult {
             try {
                 auto success = _levelDownloader->TryDownloadLevelAsync(levelId, std::bind(&MpLevelLoader::Report, this, std::placeholders::_1)).get();
                 if (!success) {


### PR DESCRIPTION
This should fix crashes, hopefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependencies, including beatsaverplusplus to 0.2.2.
  - Refreshed shared dependency configuration with new versions, metadata, and schema reference for improved tooling compatibility.

- Refactor
  - Migrated several background operations (media loading, authentication, entitlement checks, and level downloads) to task-based async execution, improving reliability and compatibility without changing user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->