### PR TITLE
Catch JsonConvert_DeserializeObject exceptions too

### DIFF
--- a/src/Hooks/MultiplayerStatusModelHooks.cpp
+++ b/src/Hooks/MultiplayerStatusModelHooks.cpp
@@ -28,8 +28,14 @@ MAKE_AUTO_HOOK_FIND_VERBOSE(JsonConvert_DeserializeObject_MultiplayerStatusData,
         return MultiplayerCore::Models::MpStatusData::New_ctor(value);
     } else {
         DEBUG("JsonConvert_DeserializeObject_MultiplayerStatusData orig call");
-        // call orig here, remember to pass the info parameter to your orig call!
-        return JsonConvert_DeserializeObject_MultiplayerStatusData(value, info);
+        try {
+            // call orig here, remember to pass the info parameter to your orig call!
+            return JsonConvert_DeserializeObject_MultiplayerStatusData(value, info);
+        } catch (...) {
+            WARNING("JsonConvert_DeserializeObject_MultiplayerStatusData exception caught, we have invalid json somewhere, printing backtrace for debugging...");
+            Paper::Logger::Backtrace(40);
+            return nullptr;
+        }
     }
 }
 


### PR DESCRIPTION
Kinda missed that, should prevent the game from crashing when parsing invalid json for v4 maps and other things that use deserialize object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for multiplayer status data synchronization, enhancing stability when processing remote player information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->